### PR TITLE
Version 3.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Generator](https://openapi-generator.tech) project.  By using the
 generate an API client. 
 
 - API version: 2019.10
-- Package version: 3.0.1
+- Package version: 3.0.2
 - Build package: org.openapitools.codegen.languages.GoClientCodegen
 For more information, please visit [https://docs.dyspatch.io](https://docs.dyspatch.io)
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1658,9 +1658,7 @@ components:
     DraftsRead:
       properties:
         cursor:
-          description: Information about paginated results
-          properties: {}
-          type: object
+          $ref: '#/components/schemas/cursor'
         data:
           description: A list of draft metadata objects
           items:

--- a/configuration.go
+++ b/configuration.go
@@ -66,7 +66,7 @@ func NewConfiguration() *Configuration {
 	cfg := &Configuration{
 		BasePath:      "https://api.dyspatch.io",
 		DefaultHeader: make(map[string]string),
-		UserAgent:     "OpenAPI-Generator/3.0.1/go",
+		UserAgent:     "OpenAPI-Generator/3.0.2/go",
 		Debug:         false,
 	}
 	return cfg

--- a/docs/DraftsRead.md
+++ b/docs/DraftsRead.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Cursor** | [**map[string]interface{}**](.md) | Information about paginated results | [optional] 
+**Cursor** | [**Cursor**](cursor.md) |  | [optional] 
 **Data** | [**[]DraftMetaRead**](DraftMetaRead.md) | A list of draft metadata objects | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/go.mod
+++ b/go.mod
@@ -4,3 +4,5 @@ require (
 	github.com/antihax/optional v1.0.0
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 )
+
+go 1.13

--- a/model_drafts_read.go
+++ b/model_drafts_read.go
@@ -11,8 +11,7 @@
 package dyspatch
 // DraftsRead struct for DraftsRead
 type DraftsRead struct {
-	// Information about paginated results
-	Cursor map[string]interface{} `json:"cursor,omitempty"`
+	Cursor Cursor `json:"cursor,omitempty"`
 	// A list of draft metadata objects
 	Data []DraftMetaRead `json:"data,omitempty"`
 }


### PR DESCRIPTION
DraftsRead model now has a Cursor struct instead of generic string map to work
with.